### PR TITLE
230 - Update org.eclipse.core.runtime to newer version

### DIFF
--- a/features/org.openhab.deps.runtime/feature.xml
+++ b/features/org.openhab.deps.runtime/feature.xml
@@ -484,7 +484,7 @@
          id="org.eclipse.equinox.common"
          download-size="0"
          install-size="0"
-         version="3.6.200.v20130402-1505"
+         version="3.7.0.v20150402-1709"
          unpack="false"/>
 
    <plugin

--- a/features/org.openhab.deps.test/feature.xml
+++ b/features/org.openhab.deps.test/feature.xml
@@ -37,7 +37,7 @@
          id="org.eclipse.core.runtime"
          download-size="0"
          install-size="0"
-         version="3.10.0.v20140318-2214"
+         version="3.11.1.v20150903-1804"
          unpack="false"/>
 
    <plugin


### PR DESCRIPTION
Update the version of two plug-ins - org.eclipse.equinox.common and org.eclipse.core.runtime (the first one depends on the runtime plug-in). This should fix openhab/openhab-distro#230.

Signed-off-by: Svilen Valkanov, svilen.valkanov@musala.com (github:
svilenvul)