### PR TITLE
Upgrade from Photon to 2019-03

### DIFF
--- a/features/org.openhab.deps.runtime/feature.xml
+++ b/features/org.openhab.deps.runtime/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.openhab.deps.runtime"
       label="org.openhab.deps.runtime"
-      version="1.0.40">
+      version="1.0.41">
 
    <description>
       Feature bundling all openHAB runtime dependencies, except openHAB and SmartHome bundles.
@@ -244,7 +244,7 @@
          id="org.eclipse.osgi"
          download-size="0"
          install-size="0"
-         version="3.13.0.v20180409-1500"
+         version="3.13.300.v20190125-2016"
          unpack="false"/>
 
    <plugin
@@ -419,14 +419,14 @@
          id="org.eclipse.equinox.ds"
          download-size="0"
          install-size="0"
-         version="1.5.100.v20171221-2204"
+         version="1.6.0.v20190122-0806"
          unpack="false"/>
 
    <plugin
          id="org.apache.felix.scr"
          download-size="0"
          install-size="0"
-         version="2.0.14.v20180117-1452"
+         version="2.1.14.v20190123-1619"
          unpack="false"/>
 
    <plugin
@@ -596,7 +596,7 @@
          id="org.eclipse.equinox.common"
          download-size="0"
          install-size="0"
-         version="3.10.0.v20180412-1130"
+         version="3.10.300.v20190122-1234"
          unpack="false"/>
 
    <plugin
@@ -631,7 +631,7 @@
          id="org.eclipse.equinox.cm"
          download-size="0"
          install-size="0"
-         version="1.3.0.v20180418-1839"
+         version="1.4.0.v20190117-0418"
          unpack="false"/>
 
    <plugin

--- a/features/org.openhab.deps.runtime/pom.xml
+++ b/features/org.openhab.deps.runtime/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.openhab.deps</groupId>
     <artifactId>pom</artifactId>
-    <version>1.0.40</version>
+    <version>1.0.41</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/features/org.openhab.deps.test/feature.xml
+++ b/features/org.openhab.deps.test/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.openhab.deps.test"
       label="org.openhab.deps.test"
-      version="1.0.40">
+      version="1.0.41">
 
    <description>
       Feature bundling all openHAB test dependencies.
@@ -30,7 +30,7 @@
          id="org.eclipse.core.runtime"
          download-size="0"
          install-size="0"
-         version="3.14.0.v20180417-0825"
+         version="3.15.100.v20181107-1343"
          unpack="false"/>
 
    <plugin
@@ -44,14 +44,14 @@
          id="org.eclipse.core.jobs"
          download-size="0"
          install-size="0"
-         version="3.10.0.v20180427-1454"
+         version="3.10.200.v20180912-1356"
          unpack="false"/>
 
    <plugin
          id="org.eclipse.equinox.preferences"
          download-size="0"
          install-size="0"
-         version="3.7.100.v20180510-1129"
+         version="3.7.200.v20180827-1235"
          unpack="false"/>
 
    <plugin
@@ -65,7 +65,7 @@
          id="org.eclipse.equinox.app"
          download-size="0"
          install-size="0"
-         version="1.3.500.v20171221-2204"
+         version="1.4.0.v20181009-1752"
          unpack="false"/>
 
    <plugin
@@ -114,7 +114,7 @@
          id="org.eclipse.equinox.launcher"
          download-size="0"
          install-size="0"
-         version="1.5.0.v20180512-1130"
+         version="1.5.200.v20180922-1751"
          unpack="false"/>
 
    <plugin

--- a/features/org.openhab.deps.test/pom.xml
+++ b/features/org.openhab.deps.test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.openhab.deps</groupId>
     <artifactId>pom</artifactId>
-    <version>1.0.40</version>
+    <version>1.0.41</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/p2/org.openhab.deps.repository/pom.xml
+++ b/p2/org.openhab.deps.repository/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.openhab.deps</groupId>
 		<artifactId>pom</artifactId>
-		<version>1.0.40</version>
+		<version>1.0.41</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>org.openhab.deps</groupId>
     <artifactId>pom</artifactId>
-    <version>1.0.40</version>
+    <version>1.0.41</version>
     <packaging>pom</packaging>
 
     <name>openHAB Dependencies Repository</name>
@@ -166,8 +166,8 @@
             <layout>p2</layout>
         </repository>
         <repository>
-            <id>p2-eclipse-photon-releases</id>
-            <url>http://download.eclipse.org/releases/photon</url>
+            <id>p2-eclipse-2019-03-releases</id>
+            <url>http://download.eclipse.org/releases/2019-03</url>
             <layout>p2</layout>
         </repository>
         <repository>


### PR DESCRIPTION
For Java 11 compatibility Xtext 2.17 is required which is available in the Eclipse 2019-03 release.

See also: https://github.com/openhab/openhab-core/pull/650

