### PR TITLE
Fix missing plugins

### DIFF
--- a/features/org.openhab.deps.runtime/feature.xml
+++ b/features/org.openhab.deps.runtime/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.openhab.deps.runtime"
       label="org.openhab.deps.runtime"
-      version="1.0.41">
+      version="1.0.42">
 
    <description>
       Feature bundling all openHAB runtime dependencies, except openHAB and SmartHome bundles.
@@ -24,7 +24,7 @@
          id="com.google.guava"
          download-size="0"
          install-size="0"
-         version="15.0.0.v201403281430"
+         version="21.0.0.v20170206-1425"
          unpack="false"/>
 
    <plugin
@@ -244,7 +244,7 @@
          id="org.eclipse.osgi"
          download-size="0"
          install-size="0"
-         version="3.13.300.v20190125-2016"
+         version="3.13.300.v20190218-1622"
          unpack="false"/>
 
    <plugin
@@ -596,7 +596,7 @@
          id="org.eclipse.equinox.common"
          download-size="0"
          install-size="0"
-         version="3.10.300.v20190122-1234"
+         version="3.10.300.v20190218-2100"
          unpack="false"/>
 
    <plugin

--- a/features/org.openhab.deps.runtime/pom.xml
+++ b/features/org.openhab.deps.runtime/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.openhab.deps</groupId>
     <artifactId>pom</artifactId>
-    <version>1.0.41</version>
+    <version>1.0.42</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/features/org.openhab.deps.test/feature.xml
+++ b/features/org.openhab.deps.test/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.openhab.deps.test"
       label="org.openhab.deps.test"
-      version="1.0.41">
+      version="1.0.42">
 
    <description>
       Feature bundling all openHAB test dependencies.
@@ -30,7 +30,7 @@
          id="org.eclipse.core.runtime"
          download-size="0"
          install-size="0"
-         version="3.15.100.v20181107-1343"
+         version="3.15.200.v20190301-1641"
          unpack="false"/>
 
    <plugin
@@ -44,14 +44,14 @@
          id="org.eclipse.core.jobs"
          download-size="0"
          install-size="0"
-         version="3.10.200.v20180912-1356"
+         version="3.10.300.v20190215-2048"
          unpack="false"/>
 
    <plugin
          id="org.eclipse.equinox.preferences"
          download-size="0"
          install-size="0"
-         version="3.7.200.v20180827-1235"
+         version="3.7.300.v20190218-2100"
          unpack="false"/>
 
    <plugin
@@ -65,7 +65,14 @@
          id="org.eclipse.equinox.app"
          download-size="0"
          install-size="0"
-         version="1.4.0.v20181009-1752"
+         version="1.4.100.v20190215-2139"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.equinox.registry"
+         download-size="0"
+         install-size="0"
+         version="3.8.300.v20190218-2100"
          unpack="false"/>
 
    <plugin
@@ -114,7 +121,7 @@
          id="org.eclipse.equinox.launcher"
          download-size="0"
          install-size="0"
-         version="1.5.200.v20180922-1751"
+         version="1.5.300.v20190213-1655"
          unpack="false"/>
 
    <plugin

--- a/features/org.openhab.deps.test/pom.xml
+++ b/features/org.openhab.deps.test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.openhab.deps</groupId>
     <artifactId>pom</artifactId>
-    <version>1.0.41</version>
+    <version>1.0.42</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/p2/org.openhab.deps.repository/pom.xml
+++ b/p2/org.openhab.deps.repository/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.openhab.deps</groupId>
 		<artifactId>pom</artifactId>
-		<version>1.0.41</version>
+		<version>1.0.42</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>org.openhab.deps</groupId>
     <artifactId>pom</artifactId>
-    <version>1.0.41</version>
+    <version>1.0.42</version>
     <packaging>pom</packaging>
 
     <name>openHAB Dependencies Repository</name>


### PR DESCRIPTION
Apparently there were still some issues in #12 because Jenkins fails to build openhab2-addons now.
I could reproduce this with an empty local Maven repo and added the fixes in this PR.

For updating the `ohdr.version` to 1.0.42 there is: https://github.com/openhab/openhab-core/pull/666